### PR TITLE
Split Dockerimage telegraf config dirs into static and dynamic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,8 @@ RUN pip install --no-cache-dir -r requirements.txt && \
 
 RUN chmod g+w /etc
 COPY --chown=telegraf:0 conf/telegraf.conf  /etc/telegraf/telegraf.conf
-COPY --chown=telegraf:0 conf/nuodb.conf     /etc/telegraf/telegraf.d/nuodb.conf
-COPY --chown=telegraf:0 conf/outputs.conf   /etc/telegraf/telegraf.d/outputs.conf
+COPY --chown=telegraf:0 conf/nuodb.conf     /etc/telegraf/telegraf.d/static/nuodb.conf
+COPY --chown=telegraf:0 conf/outputs.conf   /etc/telegraf/telegraf.d/dynamic/outputs.conf
 
 USER 1000:0
 


### PR DESCRIPTION
The static directory contains input plugins that are considered to be standard.
The dynamic directory is expected to be overridden by dynamic volumes in Docker and Kubernetes. The default `outputs.conf` file remains there as an example.