### PR TITLE
Allow for Admin Process Collector Daemons and silence error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This repository contains a Docker Compose file (`docker-compose.yml`) which will
 - 2 Admin Processes
 - 1 Storage Manager
 - 2 Transaction Engines
-- 2 NuoDB Collector containers (1 for SM, 1 for TE)
+- 3 NuoDB Collector containers (1 for SM, 1 for TE, 1 for AP)
 - InfluxDB database
 
 Clone the NuoDB Collector repository and `cd` into it:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,3 +51,14 @@ services:
       NUOCMD_API_SERVER: https://nuoadmin1:8888
       NUOCD_HOSTNAME: te
     pid: 'service:te'
+  nuocd-nuoadmin1:
+    build: .
+    depends_on:
+      - nuoadmin1
+      - sm
+      - influxdb
+    environment:
+      INFLUXURL: http://influxdb:8086
+      NUOCMD_API_SERVER: https://nuoadmin1:8888
+      NUOCD_HOSTNAME: nuoadmin1
+    pid: 'service:nuoadmin1'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,11 +51,10 @@ services:
       NUOCMD_API_SERVER: https://nuoadmin1:8888
       NUOCD_HOSTNAME: te
     pid: 'service:te'
-  nuocd-nuoadmin1:
+  nuocd-admin1:
     build: .
     depends_on:
       - nuoadmin1
-      - sm
       - influxdb
     environment:
       INFLUXURL: http://influxdb:8086

--- a/nuocd/nuodb_adminquery.py
+++ b/nuocd/nuodb_adminquery.py
@@ -170,7 +170,6 @@ while True:
                 del running_local_processes[key]
 
     except subprocess.CalledProcessError:
-        print_('nuodb not running', file=sys.stderr)
         pass
     except KeyboardInterrupt:
         for key in list(running_local_processes):

--- a/nuocd/nuodb_threads.py
+++ b/nuocd/nuodb_threads.py
@@ -39,7 +39,6 @@ while True:
         _pid = subprocess.check_output(["pgrep", '^{}$'.format(process_name)])
         _pids = _pid.split()
     except subprocess.CalledProcessError:
-        print_('nuodb not running', file=sys.stderr)
         pass
     except:
         print_("Unexpected error: %s" % sys.exc_info()[0], file=sys.stderr)


### PR DESCRIPTION
Silence warnings when a collector daemon is run on the admin pod.

Currently, there are no default collectors present in the image. There might be custom expansions that want to collect data from the admin container.

Add an "empty" collector daemon to Quickstart Docker Compose