### PR TITLE
Remove hard-coded protocol from NUOCMD_API_SERVER variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     image: $DOCKER_IMAGE
     hostname: sm
     environment:
-      NUOCMD_API_SERVER: https://nuoadmin1:8888
+      NUOCMD_API_SERVER: nuoadmin1:8888
     depends_on:
     - nuoadmin1
     command: ["nuodocker", "start", "sm", "--db-name", "hockey", "--server-id", "nuoadmin1", "--dba-user", "dba", "--dba-password", "goalie"]
@@ -18,7 +18,7 @@ services:
     image: $DOCKER_IMAGE
     hostname: te
     environment:
-      NUOCMD_API_SERVER: https://nuoadmin1:8888
+      NUOCMD_API_SERVER: nuoadmin1:8888
     depends_on:
     - nuoadmin1
     - sm
@@ -37,7 +37,7 @@ services:
     - influxdb
     environment:
       INFLUXURL: http://influxdb:8086
-      NUOCMD_API_SERVER: https://nuoadmin1:8888
+      NUOCMD_API_SERVER: nuoadmin1:8888
       NUOCD_HOSTNAME: sm
     pid: 'service:sm'
   nuocd-te:
@@ -48,7 +48,7 @@ services:
       - influxdb
     environment:
       INFLUXURL: http://influxdb:8086
-      NUOCMD_API_SERVER: https://nuoadmin1:8888
+      NUOCMD_API_SERVER: nuoadmin1:8888
       NUOCD_HOSTNAME: te
     pid: 'service:te'
   nuocd-admin1:


### PR DESCRIPTION
Remove hard-coded protocol from NUOCMD_API_SERVER variable so that `nuocmd` command determines it automatically based on environment variables exported in the container image.
This is needed as in NuoDB 4.2 we don't ship TLS keys anymore and if keys are not pre-generated the Admin will gracefully fallback to non-SSL mode.