### PR TITLE
Clean up Python code

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ These steps are for Red Hat or CentOS bare-metal hosts or VMs. For other platfor
 
 ### 1) Install dependencies
 
-NuoDB Collector requires Python 2.7 or > 3.6, which comes installed on most distributions.
+NuoDB Collector requires Python >=3.6, which comes installed on most distributions.
 
 The instructions below use `pip` to install Python dependencies. `pip` can be installed on RedHat or CentOS as follows:
 

--- a/nuocd/metrics.py
+++ b/nuocd/metrics.py
@@ -1,8 +1,6 @@
 import sys
 import time
 
-from six import print_
-
 
 def value(v):
     if str(v):
@@ -158,7 +156,7 @@ class Monitor:
                     self._items[name] = units_mapper[unit]
                 else:
                     self._items[name] = None
-                    print_("WARN: don't know how to handle item %s..." % (name,), file=sys.stderr)
+                    sys.stderr.write("WARN: don't know how to handle item %s...\n" % (name,))
             _, xml_msg = next(self.__session)
 
         if xml_msg.tag == 'Status':
@@ -182,7 +180,7 @@ class Monitor:
 
     def send(self, lines):
         for line in lines:
-            print_(line)
+            print(line)
 
     def format(self, values):
         # timestamp is in seconds
@@ -197,7 +195,6 @@ class Monitor:
         if 'Region' in values:
             region = values['Region']
 
-        header = ["TimeStamp", "NodeType", "Hostname", "ProcessId", "NodeId", "StartId", "Database", "Region"]
         tags = "host=%s,nodetype=%s,pid=%s,nodeid=%s,startid=%s,db=%s,region=%s" % (
         hostname, nodetype, processid, nodeid,
         startid, database, region)

--- a/nuocd/nuodb_adminquery.py
+++ b/nuocd/nuodb_adminquery.py
@@ -197,8 +197,7 @@ while True:
         sys.stderr.flush()
         _sleep = options.interval - (datetime.now() - latency).total_seconds()
         try:
-            # this might not work in Python3 but, does then most of this
-            # code does not work in Python3
+            # TODO: add test coverage of failure scenarios
             if sys.exc_info()[0] == KeyboardInterrupt:
                 raise KeyboardInterrupt
 

--- a/nuocd/nuodb_threads.py
+++ b/nuocd/nuodb_threads.py
@@ -8,9 +8,6 @@ import sys
 import time
 from datetime import datetime
 
-import six
-from six import print_
-
 
 def signal_handler(sig, frame):
     sys.exit(0)
@@ -79,8 +76,8 @@ class NuoDBProcess:
 
                     self.last_measurements[thread_pid] = args
             except Exception as thread_exception:
-                print_("%s: Could not read thread stats (%s) for NuoDB process with pid (%s) due to: %s " %
-                       (module, thread_pid, self.host_pid, thread_exception), file=sys.stderr)
+                sys.stderr.write("%s: Could not read thread stats (%s) for NuoDB process with pid (%s) due to: %s\n" %
+                       (module, thread_pid, self.host_pid, thread_exception))
                 continue
 
         # clean out threads that are not running anymore
@@ -98,29 +95,29 @@ if __name__ == "__main__":
         process_begin_time = datetime.now()
         try:
             raw_pgrep = subprocess.check_output(["pgrep", '^{}$'.format(PROCESS_NAME)])
-            pids = six.ensure_text(raw_pgrep).split()
+            pids = raw_pgrep.decode("utf-8").split()
             for pid in pids:
                 if pid not in known_nuodb_processes.keys():
                     proc = NuoDBProcess(pid)
                     known_nuodb_processes[pid] = proc
-                    print_("%s: Found new NuoDB process with pid (%s)." % (module, pid), file=sys.stderr)
+                    sys.stderr.write("%s: Found new NuoDB process with pid (%s).\n" % (module, pid))
 
             for known_pid in known_nuodb_processes.keys():
                 if known_pid not in pids:
                     del known_nuodb_processes[known_pid]
-                    print_("%s: NuoDB process with pid (%s) exited." % (module, pid), file=sys.stderr)
+                    sys.stderr.write("%s: NuoDB process with pid (%s) exited.\n" % (module, pid))
 
         except subprocess.CalledProcessError:
             pass
         except:
-            print_("%s: Unexpected error: %s" % (module, sys.exc_info()[0]), file=sys.stderr)
+            sys.stderr.write("%s: Unexpected error: %s\n" % (module, sys.exc_info()[0]))
             pass
 
         for pid, process in known_nuodb_processes.items():
             try:
                 process.read()
             except Exception as e:
-                print_("%s: Reading thread stats of NuoDB process with pid (%s) failed due to exception: %s" % (module, pid, e), file=sys.stderr)
+                sys.stderr.write("%s: Reading thread stats of NuoDB process with pid (%s) failed due to exception: %s\n" % (module, pid, e))
                 del known_nuodb_processes[pid]
 
         sys.stdout.flush()

--- a/nuocd/synctrace.py
+++ b/nuocd/synctrace.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from six import *
 
 """
 <SyncTrace NodeId="1" PID="1313" SampleTime="255193801">
@@ -25,7 +24,7 @@ class Monitor:
         self._relative = relative
         self._lastnow = None
         self._stalls = (0, {})
-        print_(Monitor.header)
+        print(Monitor.header)
 
     format = "%s,%d,%d,%s,%d,%s,%d,%d,%s,%d,%d,%d,%d,%d"
     header = "#time,id,startId,host,pid,dbname,timedelta,totalSumStalls,name,numLocks,numUnlocks,numStalls,totalTimeStalls,maxStallTime"
@@ -69,7 +68,7 @@ class Monitor:
                         numStalls -= ostalls[name][2]
                         totalTimeStalls -= ostalls[name][3]
                     if numStalls > 0:
-                        print_(Monitor.format % (
+                        print(Monitor.format % (
                         ntime, nodeId, startId, hostname, pid, dbname, timedelta, total - ototal, name,
                         numLocks, numUnlocks, numStalls, totalTimeStalls, maxStallTime))
         else:
@@ -78,5 +77,5 @@ class Monitor:
             else:
                 timedelta = 0
             for name, (numLocks, numUnlocks, numStalls, totalTimeStalls, maxStallTime) in stalls.items():
-                print_(Monitor.format % (ntime, nodeId, startId, hostname, pid, dbname, timedelta, total, name,
+                print(Monitor.format % (ntime, nodeId, startId, hostname, pid, dbname, timedelta, total, name,
                                          numLocks, numUnlocks, numStalls, totalTimeStalls, maxStallTime))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,5 @@
-testresources==2.0.1
-requests == 2.24.0 ; python_version <= "2.7"
-requests >= 2.27.1 ; python_version >= "3.6"
-PyYAML >= 5.3.1,<= 5.4.1 ; python_version <= "2.7"
-PyYAML >= 5.4.1 ; python_version >= "3.6"
+requests >= 2.32.0
+PyYAML >= 5.4.1
 pynuodb >= 2.5.1
 pynuoadmin >= 2.2.0
-Flask >= 1.1.2, < 2.0.0 ; python_version <= "2.7"
-Flask >= 1.1.2 ; python_version >= "3.6"
-six >= 1.14.0
+Flask >= 2.2.5


### PR DESCRIPTION
- Remove unused testresources dependency, which seems to be a test dependency and should not be packaged in the image even if it was used in the tests (it is apparently not).
- Bump versions of requests and Flask to address CVEs.
- Remove Python 2 compatibility, which is not necessary since the image includes Python 3.