### PR TITLE
Stabilize tests and suppress error messages

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-NUODB_IMAGE=nuodb/nuodb:5.0.1
+NUODB_IMAGE=nuodb/nuodb:5.1.2
 INFLUXDB_IMAGE=influxdb:2.7
 
 DOCKER_INFLUXDB_INIT_MODE=setup

--- a/nuocd/synctrace.py
+++ b/nuocd/synctrace.py
@@ -58,17 +58,21 @@ class Monitor:
         nodeId = self._process.node_id
 
         if self._relative:
+            # output delta
             if self._lastnow:
-                # output delta
                 timedelta = int((now - self._lastnow).total_seconds() * 1000000)
-                for name, (numLocks, numUnlocks, numStalls, totalTimeStalls, maxStallTime) in stalls.items():
-                    if name in ostalls:
-                        numLocks -= ostalls[name][0]
-                        numUnlocks -= ostalls[name][1]
-                        numStalls -= ostalls[name][2]
-                        totalTimeStalls -= ostalls[name][3]
-                    if numStalls > 0:
-                        print(Monitor.format % (
+            else:
+                timedelta = 0
+
+            for name, (numLocks, numUnlocks, numStalls, totalTimeStalls, maxStallTime) in stalls.items():
+                if name in ostalls:
+                    numLocks -= ostalls[name][0]
+                    numUnlocks -= ostalls[name][1]
+                    numStalls -= ostalls[name][2]
+                    totalTimeStalls -= ostalls[name][3]
+                # emit data if number of stalls increased or this is the first sample
+                if numStalls > 0 or not self._lastnow:
+                    print(Monitor.format % (
                         ntime, nodeId, startId, hostname, pid, dbname, timedelta, total - ototal, name,
                         numLocks, numUnlocks, numStalls, totalTimeStalls, maxStallTime))
         else:
@@ -77,5 +81,6 @@ class Monitor:
             else:
                 timedelta = 0
             for name, (numLocks, numUnlocks, numStalls, totalTimeStalls, maxStallTime) in stalls.items():
-                print(Monitor.format % (ntime, nodeId, startId, hostname, pid, dbname, timedelta, total, name,
-                                         numLocks, numUnlocks, numStalls, totalTimeStalls, maxStallTime))
+                print(Monitor.format % (
+                    ntime, nodeId, startId, hostname, pid, dbname, timedelta, total, name,
+                    numLocks, numUnlocks, numStalls, totalTimeStalls, maxStallTime))

--- a/nuocd/telegraf_reload.py
+++ b/nuocd/telegraf_reload.py
@@ -1,10 +1,11 @@
 import os
 import signal
+import sys
 
 from flask import Flask
+from wsgiref import simple_server
 
 app = Flask(__name__)
-
 
 @app.route('/reload')
 def reload():
@@ -16,8 +17,12 @@ def reload():
 
 
 if __name__ == '__main__':
-    import logging
-
-    logging.getLogger('werkzeug').disabled = True
-    #os.environ['WERKZEUG_RUN_MAIN'] = 'true'
-    app.run(debug=True, use_reloader=False)
+    port = 5000
+    try:
+        with simple_server.make_server("", port, app) as httpd:
+            sys.stderr.write("telegraf_reload: Running HTTP server on port {}\n".format(port))
+            if sys.stdin.isatty():
+                sys.stderr.write("Press CTRL+C to quit...\n")
+            httpd.serve_forever()
+    except KeyboardInterrupt:
+        sys.stderr.write("Exiting...\n")


### PR DESCRIPTION
This PR has two changes:

```
    Emit metrics from first SyncTrace message
    
    The input plugin that emits metrics from SyncTrace messages filters data
    if there is no change in number of stalls. This is problematic in the
    tests, since there may be no change in number of stalls for a very long
    time. The delta calculation is also a little weird, since it always
    ignores the first sample, even if it actually contais a non-zero number
    of stalls. This change emits metrics for the first SyncTrace message.
```

```
    Do not log to stdout in reload server
    
    This suppresses the 'Error in plugin: metric parse error: expected field
    at 1:11: " * Serving"' log message, which is due to Flask logging to
    stdout, which Telegraf expects to be used to emit metrics data only.
    This replaces the Flask development server with the WSGI reference
    implementation server, which does not log anything to stdout.
```